### PR TITLE
Fix WIDTH related warnings reported by verilator lint

### DIFF
--- a/rtl/verilog/or1k_marocchino_ctrl.v
+++ b/rtl/verilog/or1k_marocchino_ctrl.v
@@ -416,7 +416,7 @@ module or1k_marocchino_ctrl
         default    : spr_epcr <= epcr_default;  // by default
       endcase
     end
-    else if ((`SPR_OFFSET(spr_sys_group_wadr_r) == `SPR_OFFSET(`OR1K_SPR_EPCR0_ADDR)) &
+    else if ((`SPR_OFFSET(({1'b0, spr_sys_group_wadr_r})) == `SPR_OFFSET(`OR1K_SPR_EPCR0_ADDR)) &
              spr_sys_group_we) begin
       spr_epcr <= spr_sys_group_wdat_r;
     end
@@ -448,7 +448,7 @@ module or1k_marocchino_ctrl
   always @(posedge cpu_clk) begin
     if (cpu_rst)
       spr_evbar <= {SPR_EVBAR_WIDTH{1'b0}};
-    else if ((`SPR_OFFSET(spr_sys_group_wadr_r) == `SPR_OFFSET(`OR1K_SPR_EVBAR_ADDR)) &
+    else if ((`SPR_OFFSET(({1'b0, spr_sys_group_wadr_r})) == `SPR_OFFSET(`OR1K_SPR_EVBAR_ADDR)) &
              spr_sys_group_we)
       spr_evbar <= spr_sys_group_wdat_r[(OPTION_OPERAND_WIDTH-1):SPR_EVBAR_LSB];
   end // @ clock
@@ -692,7 +692,7 @@ module or1k_marocchino_ctrl
 
   assign except_fpu_enable_o = spr_fpcsr[`OR1K_FPCSR_FPEE];
 
-  wire spr_fpcsr_we = (`SPR_OFFSET(spr_sys_group_wadr_r) == `SPR_OFFSET(`OR1K_SPR_FPCSR_ADDR)) &
+  wire spr_fpcsr_we = (`SPR_OFFSET(({1'b0, spr_sys_group_wadr_r})) == `SPR_OFFSET(`OR1K_SPR_FPCSR_ADDR)) &
                       spr_sys_group_we &  spr_sr[`OR1K_SPR_SR_SM];
 
  `ifdef OR1K_FPCSR_MASK_FLAGS
@@ -763,7 +763,7 @@ module or1k_marocchino_ctrl
       spr_sr[`OR1K_SPR_SR_OV ]  <= wrbk_except_overflow_div_i | wrbk_except_overflow_1clk_i;
       spr_sr[`OR1K_SPR_SR_DSX]  <= wrbk_delay_slot_i;
     end
-    else if ((`SPR_OFFSET(spr_sys_group_wadr_r) == `SPR_OFFSET(`OR1K_SPR_SR_ADDR)) &
+    else if ((`SPR_OFFSET(({1'b0, spr_sys_group_wadr_r})) == `SPR_OFFSET(`OR1K_SPR_SR_ADDR)) &
              spr_sys_group_we &
              spr_sr[`OR1K_SPR_SR_SM]) begin
       // from SPR bus
@@ -796,7 +796,7 @@ module or1k_marocchino_ctrl
       spr_esr <= SPR_SR_RESET_VALUE;
     else if (wrbk_an_except_i)
       spr_esr <= spr_sr; // by exceptions
-    else if ((`SPR_OFFSET(spr_sys_group_wadr_r) == `SPR_OFFSET(`OR1K_SPR_ESR0_ADDR)) &
+    else if ((`SPR_OFFSET(({1'b0, spr_sys_group_wadr_r})) == `SPR_OFFSET(`OR1K_SPR_ESR0_ADDR)) &
              spr_sys_group_we)
       spr_esr <= spr_sys_group_wdat_r[SPR_SR_WIDTH-1:0];
   end // @ clock
@@ -830,7 +830,7 @@ module or1k_marocchino_ctrl
 
 
   // NPC for SPR (write accesses implemented for Debug System only)
-  assign du_npc_we = ((`SPR_OFFSET(spr_sys_group_wadr_r) == `SPR_OFFSET(`OR1K_SPR_NPC_ADDR)) &
+  assign du_npc_we = ((`SPR_OFFSET(({1'b0, spr_sys_group_wadr_r})) == `SPR_OFFSET(`OR1K_SPR_NPC_ADDR)) &
                       spr_sys_group_we & spr_bus_wait_du_ack);
   // --- Actually it is used just to restart CPU after salling by DU ---
   always @(posedge cpu_clk) begin
@@ -1191,7 +1191,7 @@ module or1k_marocchino_ctrl
   // ---
   always @(*) begin
     // synthesis parallel_case
-    case(`SPR_OFFSET(spr_sys_group_wadr_r))
+    case(`SPR_OFFSET(({1'b0, spr_sys_group_wadr_r})))
       `SPR_OFFSET(`OR1K_SPR_VR_ADDR)      : spr_sys_group_dat = spr_vr;
       `SPR_OFFSET(`OR1K_SPR_UPR_ADDR)     : spr_sys_group_dat = spr_upr;
       `SPR_OFFSET(`OR1K_SPR_CPUCFGR_ADDR) : spr_sys_group_dat = spr_cpucfgr;

--- a/rtl/verilog/or1k_marocchino_dcache.v
+++ b/rtl/verilog/or1k_marocchino_dcache.v
@@ -314,8 +314,8 @@ module or1k_marocchino_dcache
 
   // DCACHE "chip select" / invalidation / data output
   wire spr_dc_cs  = spr_bus_stb_r & (spr_bus_addr_r[14:11] == `OR1K_SPR_DC_BASE);
-  wire spr_dc_inv = spr_bus_we_r & ((`SPR_OFFSET(spr_bus_addr_r) == `SPR_OFFSET(`OR1K_SPR_DCBFR_ADDR)) |
-                                    (`SPR_OFFSET(spr_bus_addr_r) == `SPR_OFFSET(`OR1K_SPR_DCBIR_ADDR)));
+  wire spr_dc_inv = spr_bus_we_r & ((`SPR_OFFSET(({1'b0, spr_bus_addr_r})) == `SPR_OFFSET(`OR1K_SPR_DCBFR_ADDR)) |
+                                    (`SPR_OFFSET(({1'b0, spr_bus_addr_r})) == `SPR_OFFSET(`OR1K_SPR_DCBIR_ADDR)));
   assign spr_bus_dat_o = {OPTION_OPERAND_WIDTH{1'b0}};
 
 

--- a/rtl/verilog/or1k_marocchino_dmmu.v
+++ b/rtl/verilog/or1k_marocchino_dmmu.v
@@ -228,7 +228,7 @@ module or1k_marocchino_dmmu
         if (spr_dmmu_cs) begin
           dtlb_match_spr_cs_r <= (|spr_bus_addr_r[10:9]) & ~spr_bus_addr_r[7];
           dtlb_trans_spr_cs_r <= (|spr_bus_addr_r[10:9]) &  spr_bus_addr_r[7];
-          dmmucr_spr_cs_r     <= (`SPR_OFFSET(spr_bus_addr_r) == `SPR_OFFSET(`OR1K_SPR_DMMUCR_ADDR));
+          dmmucr_spr_cs_r     <= (`SPR_OFFSET(({1'b0, spr_bus_addr_r})) == `SPR_OFFSET(`OR1K_SPR_DMMUCR_ADDR));
           spr_way_idx_r       <= spr_way_idx[WAYS_WIDTH-1:0];
           spr_access_addr_r   <= spr_bus_addr_r[OPTION_DMMU_SET_WIDTH-1:0];
         end

--- a/rtl/verilog/or1k_marocchino_icache.v
+++ b/rtl/verilog/or1k_marocchino_icache.v
@@ -255,7 +255,7 @@ module or1k_marocchino_icache
 
   // ICACHE "chip select" / invalidation / data output
   wire spr_ic_cs  = spr_bus_stb_r & (spr_bus_addr_r[14:11] == `OR1K_SPR_IC_BASE);
-  wire spr_ic_inv = spr_bus_we_r & (`SPR_OFFSET(spr_bus_addr_r) == `SPR_OFFSET(`OR1K_SPR_ICBIR_ADDR));
+  wire spr_ic_inv = spr_bus_we_r & (`SPR_OFFSET(({1'b0, spr_bus_addr_r})) == `SPR_OFFSET(`OR1K_SPR_ICBIR_ADDR));
   assign spr_bus_dat_o = {OPTION_OPERAND_WIDTH{1'b0}};
 
 

--- a/rtl/verilog/or1k_marocchino_immu.v
+++ b/rtl/verilog/or1k_marocchino_immu.v
@@ -221,7 +221,7 @@ module or1k_marocchino_immu
         if (spr_immu_cs) begin
           itlb_match_spr_cs_r <= (|spr_bus_addr_r[10:9]) & ~spr_bus_addr_r[7];
           itlb_trans_spr_cs_r <= (|spr_bus_addr_r[10:9]) &  spr_bus_addr_r[7];
-          immucr_spr_cs_r     <= (`SPR_OFFSET(spr_bus_addr_r) == `SPR_OFFSET(`OR1K_SPR_IMMUCR_ADDR));
+          immucr_spr_cs_r     <= (`SPR_OFFSET(({1'b0, spr_bus_addr_r})) == `SPR_OFFSET(`OR1K_SPR_IMMUCR_ADDR));
           spr_way_idx_r       <= spr_way_idx[WAYS_WIDTH-1:0];
           spr_access_addr_r   <= spr_bus_addr_r[OPTION_IMMU_SET_WIDTH-1:0];
         end

--- a/rtl/verilog/or1k_marocchino_ocb.v
+++ b/rtl/verilog/or1k_marocchino_ocb.v
@@ -464,8 +464,9 @@ module or1k_marocchino_oreg_buff
   reg  [RAM_AW-1:0] wop_addr_r; // address for write only port
 
   // Addressing arithmetic
-
+  /* verilator lint_off WIDTH */
   localparam [RAM_AW:0] RAM_ADDR_OWF = NUM_RAM_TAPS;
+  /* verilator lint_on WIDTH */
 
   wire [RAM_AW:0] rah_addr_add = rah_addr_r + 1'b1;
   wire [RAM_AW:0] wop_addr_add = wop_addr_r + 1'b1;
@@ -714,8 +715,9 @@ module or1k_marocchino_ff_oreg_buff
   reg  [RAM_AW-1:0] wop_addr_r; // address for write only port
 
   // Addressing arithmetic
-
+  /* verilator lint_off WIDTH */
   localparam [RAM_AW:0] RAM_ADDR_OWF = NUM_RAM_TAPS;
+  /* verilator lint_on WIDTH */
 
   wire [RAM_AW:0] rah_addr_add = rah_addr_r + 1'b1;
   wire [RAM_AW:0] wop_addr_add = wop_addr_r + 1'b1;

--- a/rtl/verilog/or1k_marocchino_oman.v
+++ b/rtl/verilog/or1k_marocchino_oman.v
@@ -1071,8 +1071,8 @@ module or1k_marocchino_oman
   always @(posedge cpu_clk) begin
     if (padv_wrbk_i) begin
       pc_wrbk_o      <= pc_exec;
-      pc_nxt_wrbk_o  <= pc_exec + 3'd4;
-      pc_nxt2_wrbk_o <= pc_exec + 4'd8;
+      pc_nxt_wrbk_o  <= pc_exec + 32'd4;
+      pc_nxt2_wrbk_o <= pc_exec + 32'd8;
     end
   end // @clock
 

--- a/rtl/verilog/or1k_marocchino_pic.v
+++ b/rtl/verilog/or1k_marocchino_pic.v
@@ -150,8 +150,8 @@ module or1k_marocchino_pic
         // wait SPR access request
         SPR_PIC_WAIT: begin
           if (spr_pic_cs) begin
-            spr_picmr_cs_r <= (`SPR_OFFSET(spr_bus_addr_r1) == `SPR_OFFSET(`OR1K_SPR_PICMR_ADDR));
-            spr_picsr_cs_r <= (`SPR_OFFSET(spr_bus_addr_r1) == `SPR_OFFSET(`OR1K_SPR_PICSR_ADDR));
+            spr_picmr_cs_r <= (`SPR_OFFSET(({1'b0, spr_bus_addr_r1})) == `SPR_OFFSET(`OR1K_SPR_PICMR_ADDR));
+            spr_picsr_cs_r <= (`SPR_OFFSET(({1'b0, spr_bus_addr_r1})) == `SPR_OFFSET(`OR1K_SPR_PICSR_ADDR));
             spr_pic_state  <= spr_bus_we_r1 ? SPR_PIC_WE : SPR_PIC_RE;
           end
         end

--- a/rtl/verilog/or1k_marocchino_rf.v
+++ b/rtl/verilog/or1k_marocchino_rf.v
@@ -720,7 +720,7 @@ module or1k_marocchino_rf
            ram_rfb1_out) begin
     // synthesis parallel_case
     casez ({dcod_op_jal_i, dcod_immediate_sel_i, wrb2dec_d1b1_fwd})
-      3'b1??:  dcod_rfb1_o = 4'd8; // (FEATURE_DELAY_SLOT == "ENABLED")
+      3'b1??:  dcod_rfb1_o = 32'd8; // (FEATURE_DELAY_SLOT == "ENABLED")
       3'b01?:  dcod_rfb1_o = dcod_immediate_i;
       3'b001:  dcod_rfb1_o = wrbk_result1_i;
       default: dcod_rfb1_o = ram_rfb1_out;

--- a/rtl/verilog/or1k_marocchino_ticktimer.v
+++ b/rtl/verilog/or1k_marocchino_ticktimer.v
@@ -146,8 +146,8 @@ module or1k_marocchino_ticktimer
         // wait SPR access request
         SPR_TT_WAIT: begin
           if (spr_tt_cs) begin
-            spr_ttmr_cs_r <= (`SPR_OFFSET(spr_bus_addr_r1) == `SPR_OFFSET(`OR1K_SPR_TTMR_ADDR));
-            spr_ttcr_cs_r <= (`SPR_OFFSET(spr_bus_addr_r1) == `SPR_OFFSET(`OR1K_SPR_TTCR_ADDR));
+            spr_ttmr_cs_r <= (`SPR_OFFSET(({1'b0, spr_bus_addr_r1})) == `SPR_OFFSET(`OR1K_SPR_TTMR_ADDR));
+            spr_ttcr_cs_r <= (`SPR_OFFSET(({1'b0, spr_bus_addr_r1})) == `SPR_OFFSET(`OR1K_SPR_TTCR_ADDR));
             spr_tt_state  <= spr_bus_we_r1 ? SPR_TT_WE : SPR_TT_RE;
           end
         end


### PR DESCRIPTION
This is many of the fixes for the WIDTH related issues I could get to this morning.

One remains, the truncating may be on purpose...

```
%Warning-WIDTH: rtl/verilog/pfpu_marocchino/pfpu_marocchino_muldiv.v:426: Operator ASSIGNW expects 13 bits on the Assign RHS, but Assign RHS's SUB generates 14 bits.
```

Code:

```
  // right shift value                                                          
  // and appropriatelly corrected exponent                                      
  wire s1o_exp13c_0              = ~(|s1o_exp13c);                              
  wire [12:0] s2t_shr_of_neg_exp = 14'h2001 - {1'b0,s1o_exp13c}; // 8192-v+1
```