### PR TITLE
fusesoc: Fix yosys synthesis target

### DIFF
--- a/or1k_marocchino.core
+++ b/or1k_marocchino.core
@@ -78,8 +78,8 @@ targets:
 
   synth:
     default_tool : icestorm
-    filesets : [core]
+    filesets : [core, fpu_marocchino]
     tools:
       icestorm:
         pnr: none
-    toplevel : or1k_marocchino
+    toplevel : or1k_marocchino_top


### PR DESCRIPTION
We must have FPU enabled for marocchino also use the correct top level.
Getting out of memory errors with my version of yosys committing this
to test and record results on CI.